### PR TITLE
Profile avatars

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,20 +6,20 @@
 
 ``` bash
 # install dependencies
-$ npm run install
+$ yarn install
 
 # serve with hot reload at localhost:3000
-$ npm run dev
+$ yarn dev
 
 # build for production and launch server
-$ npm run build
-$ npm run start
+$ yarn build
+$ yarn start
 
 # generate static project
-$ npm run generate
+$ yarn generate
 
 # deploy static project to gh-pages branch
-$ npm run deploy
+$ yarn deploy
 
 ```
 

--- a/components/ProfileAvatar.vue
+++ b/components/ProfileAvatar.vue
@@ -1,0 +1,45 @@
+<template>
+  <span 
+    class="circle shadow-outline cursor-default f5 fw3 white"
+    :style="styleObject"
+    :title="profileName"
+  >{{initial}}</span>
+</template>
+<script>
+export default {
+  props: {
+    profileName: { type: String, default: "User Name" },
+    borderColor: { type: String, default: "transparent" },
+    backgroundColor: { type: String, default: "orange" },
+  },
+  computed: {
+    initial() {
+      return this.profileName[0].toUpperCase();
+    },
+    styleObject() {
+      return {
+        'box-shadow': '0 0 0 0.3rem ' + this.borderColor,
+        'background-color': this.backgroundColor,
+      } 
+    },
+  }
+};
+</script>
+<style scoped>
+.circle {
+  display: inline-block;
+  width: 2em;
+  height: 2em;
+  line-height: 2em;
+  text-align: center;
+  border-radius: 50%;
+}
+.shadow-outline {
+  box-shadow: 0 0 0 0.5rem yellow;
+  background-color: 
+}
+.cursor-default {
+  cursor: default;
+}
+
+</style>

--- a/components/ProfileAvatarList.vue
+++ b/components/ProfileAvatarList.vue
@@ -1,0 +1,22 @@
+<template>
+  <ul class="flex list pa0 flex-wrap pv1">
+    <li v-for="profileName in profileNames">
+      <ProfileAvatar
+        :profileName="profileName"
+        :borderColor="borderColor"
+        :backgroundColor="backgroundColor"
+      />
+    </li>
+  </ul>
+</template>
+<script>
+import ProfileAvatar from "~/components/ProfileAvatar.vue";
+export default {
+  props: {
+    profileNames: { type: Array, default: () => [] },
+    borderColor: { type: String, default: "transparent" },
+    backgroundColor: { type: String, default: "#00449e" },
+  },
+  components: { ProfileAvatar },
+};
+</script>

--- a/components/SessionCardPreview.vue
+++ b/components/SessionCardPreview.vue
@@ -1,5 +1,5 @@
 <template>
-  <article class="tl bg-near-white br3 hover-shadow-raise">
+  <article class="tl bg-light-gray br3 hover-shadow-raise">
     <nuxt-link :to="path" class="link black">
       <div class="flex flex-column">
         <div class="w-100 aspect-ratio aspect-ratio--16x9">

--- a/components/SessionCardPreview.vue
+++ b/components/SessionCardPreview.vue
@@ -25,17 +25,17 @@
             <div class="flex flex-wrap mb2">
               <div class="mr3">
                 <h3 class="f5 fw4 o-60">shared by</h3>
-                <ProfilePicList
-                  :profilePics="sharers"
-                  borderColorClass="b--near-white"
+                <ProfileAvatarList
+                  :profileNames="sharerNames"
+                  borderColor="#EEEEEE"
                 />
               </div>
               <div>
                 <h3 v-if="hasHappened" class="f5 fw4 o-60">learned by</h3>
                 <h3 v-else class="f5 fw4 o-60">like to learn</h3>
-                <ProfilePicList
-                  :profilePics="learners"
-                  borderColorClass="b--near-white"
+                <ProfileAvatarList
+                  :profileNames="learnerNames"
+                  borderColor="#EEEEEE"
                 />
               </div>
             </div>
@@ -48,7 +48,7 @@
 <script>
 import ProfilePic from "~/components/ProfilePic.vue";
 import TagPill from "~/components/TagPill.vue";
-import ProfilePicList from "~/components/ProfilePicList.vue";
+import ProfileAvatarList from "~/components/ProfileAvatarList.vue";
 export default {
   props: {
     title: { type: String, default: "Title" },
@@ -56,10 +56,10 @@ export default {
     date: { type: String, default: "date" },
     imageSrc: { type: String },
     path: { type: String },
-    learners: { type: Array, default: () => [] },
-    sharers: { type: Array, default: () => [] },
+    learnerNames: { type: Array, default: () => [] },
+    sharerNames: { type: Array, default: () => [] },
   },
-  components: { ProfilePic, TagPill, ProfilePicList },
+  components: { ProfilePic, TagPill, ProfileAvatarList },
   computed: {
     hasHappened() {
       let now = new Date();

--- a/components/SessionPage.vue
+++ b/components/SessionPage.vue
@@ -55,9 +55,9 @@
           <div class="mb2 flex-shrink-0 pr3 pr4-m pr5-l">
             <p>
               Shared by
-              <ProfilePicList
-                :profilePics="hydrateMembers(session.sharerNames)"
-                borderColorClass="su-washed-orange"
+              <ProfileAvatarList
+                :profileNames="session.sharerNames"
+                borderColor="#fdecce"
               />
             </p>
           </div>
@@ -65,9 +65,9 @@
             <p>
               <span v-if="hasHappened">Learned by</span>
               <span v-else >Like to learn</span>
-              <ProfilePicList
-                :profilePics="hydrateMembers(session.learnerNames)"
-                borderColorClass="su-washed-orange"
+              <ProfileAvatarList
+                :profileNames="session.learnerNames"
+                borderColor="#fdecce"
               />
             </p>
           </div>
@@ -98,7 +98,7 @@
 <script>
 import _ from "lodash";
 import TagPill from "~/components/TagPill.vue";
-import ProfilePicList from "~/components/ProfilePicList.vue";
+import ProfileAvatarList from "~/components/ProfileAvatarList.vue";
 
 export default {
   layout: "storytellersUnited",
@@ -109,7 +109,7 @@ export default {
   },
   components: {
     TagPill,
-    ProfilePicList,
+    ProfileAvatarList,
   },
   props: {
     session: { type: Object, default: () => {} },
@@ -151,18 +151,6 @@ export default {
     },
   },
   methods: {
-    hydrateMembers(memberNames) {
-      return memberNames.map((memberName) => {
-        if (this.members[memberName]) {
-          return this.members[memberName];
-        } else {
-          return {
-            profilePic: require("@/assets/profilePic-default-32.png"),
-            userName: memberName,
-          };
-        }
-      });
-    },
     isValidDate(d) {
       if (Object.prototype.toString.call(d) === "[object Date]") {
         // it is a date

--- a/components/SessionsSection.vue
+++ b/components/SessionsSection.vue
@@ -12,8 +12,8 @@
           :date="session.date"
           :imageSrc="session.imageSrc"
           :path="session.path"
-          :learners="hydrateMembers(session.learnerNames)"
-          :sharers="hydrateMembers(session.sharerNames)"
+          :learnerNames="session.learnerNames"
+          :sharerNames="session.sharerNames"
         />
       </li>
     </ul>
@@ -27,21 +27,6 @@ export default {
   },
   props: {
     sessions: { type: Array, default: () => [] },
-    members: { type: Object, default: () => {} },
-  },
-  methods: {
-    hydrateMembers(memberNames) {
-      return memberNames.map((memberName) => {
-        if (this.members[memberName]) {
-          return this.members[memberName];
-        } else {
-          return {
-            profilePic: require("@/assets/profilePic-default-32.png"),
-            userName: memberName,
-          };
-        }
-      });
-    },
   },
 };
 </script>

--- a/pages/mozfest/index.vue
+++ b/pages/mozfest/index.vue
@@ -52,7 +52,6 @@
       <SessionsSection
         v-if="sessionsUpcoming.length"
         :sessions="sessionsUpcoming"
-        :members="members"
       >
         <h2 class="mb3">Upcoming Sessions</h2>
         <CalendarReferral />
@@ -60,7 +59,6 @@
       <SessionsSection
         v-if="sessionsPast.length"
         :sessions="sessionsPast"
-        :members="members"
       >
         <h2 class="mb3">Things we've learned so far</h2>
         <p class="f4 lh-copy">

--- a/pages/mozfest/sessions/_slug.vue
+++ b/pages/mozfest/sessions/_slug.vue
@@ -14,20 +14,6 @@ export default {
     const session = await $content('mozfest/sessions', params.slug).fetch()
     return { session }
   },
-  methods: {
-    hydrateMembers(memberNames) {
-      return memberNames.map((memberName) => {
-        if (this.members[memberName]) {
-          return this.members[memberName];
-        } else {
-          return {
-            profilePic: require("@/assets/profilePic-default-32.png"),
-            userName: memberName,
-          };
-        }
-      });
-    },
-  },
   computed: {
     hasHappened() {
       let now = new Date();

--- a/pages/storytellersunited/index.vue
+++ b/pages/storytellersunited/index.vue
@@ -52,15 +52,13 @@
       <SessionsSection
         v-if="sessionsUpcoming.length"
         :sessions="sessionsUpcoming"
-        :members="members"
       >
         <h2 class="mb3">Upcoming Sessions</h2>
         <CalendarReferral />
       </SessionsSection>
       <SessionsSection 
         v-if="sessionsPast.length"
-        :sessions="sessionsPast" 
-        :members="members"
+        :sessions="sessionsPast"
       >
         <h2 class="mb3">Things we've learned so far</h2>
         <p class="f4 lh-copy">
@@ -121,11 +119,7 @@ export default {
       })
       .fetch();
 
-    const members = await fetch(
-      "https://storytellers.link/api/members.json"
-    ).then((res) => res.json());
-
-    return { sessionsUpcoming, sessionsPast, members };
+    return { sessionsUpcoming, sessionsPast };
   },
   /* enables auth middleware (also see pages/login.vue and `auth` object in nuxt.config.js)
      after successful login, the boolean flag `this.$auth.loggedIn` indicates that user is authenticated

--- a/pages/storytellersunited/sessions/_slug.vue
+++ b/pages/storytellersunited/sessions/_slug.vue
@@ -17,20 +17,6 @@ export default {
     ).then((res) => res.json());
     return { session, members }
   },
-  methods: {
-    hydrateMembers(memberNames) {
-      return memberNames.map((memberName) => {
-        if (this.members[memberName]) {
-          return this.members[memberName];
-        } else {
-          return {
-            profilePic: require("@/assets/profilePic-default-32.png"),
-            userName: memberName,
-          };
-        }
-      });
-    },
-  },
   computed: {
     hasHappened() {
       let now = new Date();


### PR DESCRIPTION
this replaces ProfilePics with ProfileAvatars, so hydrating member names with profile images is no longer necessary and Learners and Sharers still look unique, based on their Initials. 