### PR TITLE
Session times without seconds

### DIFF
--- a/components/SessionPage.vue
+++ b/components/SessionPage.vue
@@ -43,8 +43,12 @@
               {{ dateFormatted }}
             </p>
             <p class="fw3 mb3 lh-copy">
-              <span>{{ timeFormatted }}</span>
-              <span>({{ timezone }}), </span>
+              <span class="mr1">{{ timeFormatted }}</span>
+              <span
+                class="mr1"
+                v-tooltip="{ content: timezone, trigger: 'hover click focus' }"
+                >🌐</span
+              >
               <span>{{ session.durationInMinutes }}&nbsp;min</span>
             </p>
             <a
@@ -81,7 +85,7 @@
             class="mb2 flex-shrink-0 pr3 pr4-m pr5-l"
           >
             <p>
-              <span>{{ hasHappened ? "Learned by" : "Like to learn"}}</span>
+              <span>{{ hasHappened ? "Learned by" : "Like to learn" }}</span>
               <ProfileAvatarList
                 :profileNames="session.learnerNames"
                 :borderColor="bgColor"
@@ -114,7 +118,7 @@
 <script>
 import TagPill from "~/components/TagPill.vue";
 import ProfileAvatarList from "~/components/ProfileAvatarList.vue";
-import SocialHead from './SocialHead.vue';
+import SocialHead from "./SocialHead.vue";
 import {
   formatDate,
   isValidDate,
@@ -122,12 +126,15 @@ import {
   formatTime,
   getTimezone,
 } from "~/util/date";
+import Vue from "vue";
+import VTooltip from "v-tooltip";
+Vue.use(VTooltip);
 
 export default {
   components: {
     TagPill,
     ProfileAvatarList,
-    SocialHead
+    SocialHead,
   },
   props: {
     session: { type: Object, default: () => {} },
@@ -190,5 +197,105 @@ export default {
 }
 .flex-shrink-0 {
   flex-shrink: 0;
+}
+</style>
+
+<style lang="scss">
+/* 
+  v-tooltip styling 
+  https://github.com/Akryum/v-tooltip#style-examples
+*/
+.tooltip {
+  display: block !important;
+  z-index: 10000;
+
+  .tooltip-inner {
+    background: black;
+    color: white;
+    border-radius: 16px;
+    padding: 5px 10px 4px;
+  }
+
+  .tooltip-arrow {
+    width: 0;
+    height: 0;
+    border-style: solid;
+    position: absolute;
+    margin: 5px;
+    border-color: black;
+    z-index: 1;
+  }
+
+  &[x-placement^="top"] {
+    margin-bottom: 5px;
+
+    .tooltip-arrow {
+      border-width: 5px 5px 0 5px;
+      border-left-color: transparent !important;
+      border-right-color: transparent !important;
+      border-bottom-color: transparent !important;
+      bottom: -5px;
+      left: calc(50% - 5px);
+      margin-top: 0;
+      margin-bottom: 0;
+    }
+  }
+
+  &[x-placement^="bottom"] {
+    margin-top: 5px;
+
+    .tooltip-arrow {
+      border-width: 0 5px 5px 5px;
+      border-left-color: transparent !important;
+      border-right-color: transparent !important;
+      border-top-color: transparent !important;
+      top: -5px;
+      left: calc(50% - 5px);
+      margin-top: 0;
+      margin-bottom: 0;
+    }
+  }
+
+  &[x-placement^="right"] {
+    margin-left: 5px;
+
+    .tooltip-arrow {
+      border-width: 5px 5px 5px 0;
+      border-left-color: transparent !important;
+      border-top-color: transparent !important;
+      border-bottom-color: transparent !important;
+      left: -5px;
+      top: calc(50% - 5px);
+      margin-left: 0;
+      margin-right: 0;
+    }
+  }
+
+  &[x-placement^="left"] {
+    margin-right: 5px;
+
+    .tooltip-arrow {
+      border-width: 5px 0 5px 5px;
+      border-top-color: transparent !important;
+      border-right-color: transparent !important;
+      border-bottom-color: transparent !important;
+      right: -5px;
+      top: calc(50% - 5px);
+      margin-left: 0;
+      margin-right: 0;
+    }
+  }
+
+  &[aria-hidden="true"] {
+    visibility: hidden;
+    opacity: 0;
+    transition: opacity 0.15s, visibility 0.15s;
+  }
+
+  &[aria-hidden="false"] {
+    visibility: visible;
+    opacity: 1;
+    transition: opacity 0.15s;
+  }
 }
 </style>

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "node-fetch": "^2.6.1",
     "nuxt": "^2.14.7",
     "tachyons": "^4.12.0",
+    "v-tooltip": "^2.1.2",
     "vue-d3-network": "^0.1.28"
   },
   "devDependencies": {

--- a/util/date.js
+++ b/util/date.js
@@ -6,7 +6,7 @@ export const formatDate = (date) => {
 export const formatTime = (date) => {
   // return time local to browser's timezone
   const locales = []; // [] to use browser's default locale for format
-  const options = { timeStyle: "short" };
+  const options = { hour: '2-digit', minute: '2-digit' };
   return date.toLocaleTimeString(locales, options);
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6614,6 +6614,11 @@ pkg-dir@^4.1.0:
   dependencies:
     find-up "^4.0.0"
 
+popper.js@^1.16.0:
+  version "1.16.1"
+  resolved "https://registry.yarnpkg.com/popper.js/-/popper.js-1.16.1.tgz#2a223cb3dc7b6213d740e40372be40de43e65b1b"
+  integrity sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==
+
 posix-character-classes@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz"
@@ -8917,6 +8922,15 @@ uuid@^8.0.0:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
+v-tooltip@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/v-tooltip/-/v-tooltip-2.1.2.tgz#5d3cd0c13eecdd365a0ad734b2f6c938bc8f7885"
+  integrity sha512-6c4NotnvDvinmZnBiqW50Rn6Q3MMk+pUV9Nla+JHkgJulgXh5snrU3RYbIZVf9p2ZlFoaZL/3QhTNgcQIc2GFQ==
+  dependencies:
+    lodash "^4.17.15"
+    popper.js "^1.16.0"
+    vue-resize "^1.0.0"
+
 vary@^1, vary@^1.1.2, vary@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/vary/-/vary-1.1.2.tgz"
@@ -8994,6 +9008,11 @@ vue-no-ssr@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/vue-no-ssr/-/vue-no-ssr-1.1.1.tgz"
   integrity sha512-ZMjqRpWabMPqPc7gIrG0Nw6vRf1+itwf0Itft7LbMXs2g3Zs/NFmevjZGN1x7K3Q95GmIjWbQZTVerxiBxI+0g==
+
+vue-resize@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/vue-resize/-/vue-resize-1.0.0.tgz#380565b36e411190d85f8fbd3aa230a4cc22f1a5"
+  integrity sha512-SkIi19neeJClapYavfmHiewFZkkTfITVWskg/dIL8b1Eb+RlvnCb8fjGUwLjQJmsw2qsRiiAo4o7BAJVM4pcOA==
 
 vue-router@^3.4.9:
   version "3.4.9"


### PR DESCRIPTION
- force 2 digit hour and minute times
- show timezone in tooltip

navigate to several session pages (ideally desktop and mobile) to check:
- time is properly displayed 
- timezone is accessible via hover or click on globe icon

I like that we don't show the long timezone string by default, but is this accessible enough?